### PR TITLE
fix compile errors in unity 2020.1+

### DIFF
--- a/Utils/Extensions.cs
+++ b/Utils/Extensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Boo.Lang;
 
 namespace SnowFlakeGamesAssets.TaurusDungeonGenerator.Utils
 {
@@ -57,7 +56,7 @@ namespace SnowFlakeGamesAssets.TaurusDungeonGenerator.Utils
         /// Kotlin style Let function
         /// Calls the specified function with this value as its argument and returns its result
         /// </summary>
-        public static Tr Let<T, Tr>(this T obj, Function<T, Tr> f) => f(obj);
+        public static Tr Let<T, Tr>(this T obj, Func<T, Tr> f) => f(obj);
 
         #endregion
     }


### PR DESCRIPTION
`Boo.lang` namespace is no longer available, causing a compile-time error in "Utils/Extension". Moreover, `Let()` was using a type `Function` which unresolved. I changed it to a well-known C# type, `Func`, so it may retain its functionality while resolving the compile-time error of unresolvable type.